### PR TITLE
Fix URL arguments triggering volume requester

### DIFF
--- a/src/host-multiview.c
+++ b/src/host-multiview.c
@@ -40,8 +40,8 @@ int main(int argc, char *argv[])
     {
         char *target = argv[i];
 
-        /* Try to resolve as a file path first to get the host path */
-        if (lock = Lock(argv[i], ACCESS_READ))
+        /* Try to resolve as a file path first to get the host path (skip URLs) */
+        if (!strstr(argv[i], "://") && (lock = Lock(argv[i], ACCESS_READ)))
         {
             if (NativeDosOp((ULONG)0, (ULONG)lock, (ULONG)filename, (ULONG)sizeof(filename)) == 0) {
                  UnLock(lock);

--- a/src/host-run.c
+++ b/src/host-run.c
@@ -85,9 +85,9 @@ int main(int argc, char *argv[])
 
     for (int i = 1; i < argc; i++)
     {
-        // Try to resolve as a file path first
+        // Try to resolve as a file path first (skip URLs to avoid volume requester)
         int is_resolved_file = 0;
-        if (lock = Lock(argv[i], ACCESS_READ))
+        if (!strstr(argv[i], "://") && (lock = Lock(argv[i], ACCESS_READ)))
         {
             if (NativeDosOp((ULONG)0, (ULONG)lock, (ULONG)filename, (ULONG)sizeof(filename)) == 0) {
                  UnLock(lock);


### PR DESCRIPTION
## Summary
- Skip `Lock()` call in `host-run` and `host-multiview` when an argument contains `://`, preventing AmigaOS from interpreting URL schemes (e.g. `https:`) as volume names
- This avoids the "Please insert volume https in any drive" requester when passing URLs

## Test plan
- [ ] Run `host-run open https://www.google.com` — should open browser without requester
- [ ] Run `host-multiview https://www.google.com` — should open browser without requester
- [ ] Run `host-run open <amiga-file-path>` — file path resolution should still work as before

Fixes #4