### PR TITLE
Fix bugs and improve robustness across all tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
           name: host-tools-package
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
-        with:
-          name: Host-Tools ${{ github.ref_name }}
-          files: "*.lha"
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release create ${{ github.ref_name }} *.lha --title "Host-Tools ${{ github.ref_name }}" --generate-notes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,12 @@ name: Build Amiberry Host Tools
 on:
   push:
     branches:
-      - main
+      - master
     tags:
       - 'v*'
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 permissions:
@@ -26,25 +26,14 @@ jobs:
     - name: Build tools
       run: make all
 
-    - name: Determine version
-      id: version
-      run: |
-        if [ "${{ github.ref_type }}" = "tag" ]; then
-          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-        fi
-        echo "Ref type: ${{ github.ref_type }}"
-        echo "Ref name: ${{ github.ref_name }}"
-
     - name: Package tools
       run: |
-        # Create LHA archives
-        # We assume 'lha' is installed in the container
-        # Create single LHA archive
-        if [ ! -z "$VERSION" ]; then
-          lha a "Host-Tools-${VERSION}.lha" host-run host-multiview host-shell README.md
+        if [ "${{ github.ref_type }}" = "tag" ]; then
+          VERSION="${{ github.ref_name }}"
         else
-          lha a "Host-Tools-latest.lha" host-run host-multiview host-shell README.md
+          VERSION="latest"
         fi
+        lha a "Host-Tools-${VERSION}.lha" host-run host-multiview host-shell README.md
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
@@ -56,7 +45,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -64,7 +53,7 @@ jobs:
           name: host-tools-package
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: Host-Tools ${{ github.ref_name }}
           files: "*.lha"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: host-run host-multiview host-shell
 
 CC			= m68k-amigaos-gcc
 INCLUDES	= -Isrc
-CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99
+CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99 -Wall -Wextra
 
 host-run: src/host-run.c
 	$(CC) $(CFLAGS) $(INCLUDES) src/host-run.c -o $@
@@ -13,6 +13,9 @@ host-multiview: src/host-multiview.c
 
 host-shell: src/host-shell.c
 	$(CC) $(CFLAGS) $(INCLUDES) src/host-shell.c -o $@
+
+debug: CFLAGS += -DDEBUG -g
+debug: clean all
 
 clean:
 	rm -f host-run host-multiview host-shell

--- a/src/host-multiview.c
+++ b/src/host-multiview.c
@@ -8,15 +8,15 @@ static const char __ver[40] = "$VER: Host-MultiView v1.9 (2025-12-26)";
 int print_usage()
 {
     printf("Host-MultiView v1.9\n");
-    printf("Host-MultiView is a command line tool to open files with the host default handler, from within UAE.\n");
-    printf("%s\nUsage: host-multiview <filename> [filename2 ...]\n", __ver);
+    printf("Host-MultiView is a command line tool to open files or URLs with the host default handler, from within UAE.\n");
+    printf("%s\nUsage: host-multiview <filename|URL> [filename2|URL2 ...]\n", __ver);
     return 0;
 }
 
 int main(int argc, char *argv[])
 {
     BPTR lock;
-    char filename[256];
+    char filename[1024];
 
     if (!InitUAEResource())
     {
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 
     if (argc <= 1)
     {
-        printf("Missing filename argument\n");
+        printf("Missing filename or URL argument\n");
         return print_usage();
     }
 
@@ -41,9 +41,9 @@ int main(int argc, char *argv[])
         char *target = argv[i];
 
         /* Try to resolve as a file path first to get the host path (skip URLs) */
-        if (!strstr(argv[i], "://") && (lock = Lock(argv[i], ACCESS_READ)))
+        if (!strstr(argv[i], "://") && ((lock = Lock(argv[i], ACCESS_READ))))
         {
-            if (NativeDosOp((ULONG)0, (ULONG)lock, (ULONG)filename, (ULONG)sizeof(filename)) == 0) {
+            if (NativeDosOp(0, (ULONG)lock, (ULONG)filename, sizeof(filename)) == 0) {
                  UnLock(lock);
                  target = filename;
             } else {

--- a/src/host-run.c
+++ b/src/host-run.c
@@ -41,17 +41,19 @@ void append_quoted(char *dest, const char *src, size_t max_len) {
     }
 
     for (const char *p = src; *p; p++) {
-        if (current_len >= max_len - 4) break; // Reserve space for close quote + null
-
         if (*p == '\'') {
             // Escape single quote: ' -> '\''
-            strcat(dest, "'\\''");
-            current_len += 4;
+            if (current_len + 4 >= max_len) break;
+            dest[current_len++] = '\'';
+            dest[current_len++] = '\\';
+            dest[current_len++] = '\'';
+            dest[current_len++] = '\'';
         } else {
+            if (current_len + 1 >= max_len - 1) break; // Reserve space for close quote + null
             dest[current_len++] = *p;
-            dest[current_len] = '\0';
         }
     }
+    dest[current_len] = '\0';
 
     // Closing quote
     if (needs_quote) {
@@ -64,7 +66,7 @@ int main(int argc, char *argv[])
 {
     BPTR lock;
     char command[MAX_CMD_LEN] = "";
-    char filename[256];
+    char filename[1024];
 
     if (!InitUAEResource())
     {
@@ -87,9 +89,9 @@ int main(int argc, char *argv[])
     {
         // Try to resolve as a file path first (skip URLs to avoid volume requester)
         int is_resolved_file = 0;
-        if (!strstr(argv[i], "://") && (lock = Lock(argv[i], ACCESS_READ)))
+        if (!strstr(argv[i], "://") && ((lock = Lock(argv[i], ACCESS_READ))))
         {
-            if (NativeDosOp((ULONG)0, (ULONG)lock, (ULONG)filename, (ULONG)sizeof(filename)) == 0) {
+            if (NativeDosOp(0, (ULONG)lock, (ULONG)filename, sizeof(filename)) == 0) {
                  UnLock(lock);
                  is_resolved_file = 1;
             } else {
@@ -112,6 +114,5 @@ int main(int argc, char *argv[])
 #ifdef DEBUG
     printf("DEBUG: argc=%d, command=%s\n", argc, command);
 #endif
-    ExecuteOnHost((UBYTE *)&command);
-    return 0;
+    return ExecuteOnHost((UBYTE *)command);
 }

--- a/src/host-shell.c
+++ b/src/host-shell.c
@@ -26,6 +26,15 @@ int main(int argc, char *argv[])
         return 2;
     }
 
+    if (argc == 2 && strcmp(argv[1], "?") == 0)
+    {
+        printf("Host-Shell v1.9\n");
+        printf("Host-Shell opens an interactive terminal session on the host system.\n");
+        printf("$VER: Host-Shell v1.9 (2025-12-26)\n");
+        printf("Usage: host-shell [command]\n");
+        return 0;
+    }
+
     // Combine arguments into command string
     for (int i = 1; i < argc; i++)
     {
@@ -33,7 +42,7 @@ int main(int argc, char *argv[])
         strncat(command, argv[i], sizeof(command) - strlen(command) - 1);
     }
 
-    if (DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0))
+    if ((DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0)))
     {
         in = Input();
         out = Output();


### PR DESCRIPTION
## Summary
- Fix potential buffer overflow in `append_quoted` — replaced `strcat` with direct byte copies for correct bounds checking
- Fix incorrect `&command` pointer type in `ExecuteOnHost` call
- Propagate host command exit code from `host-run` (enables `IF WARN`/`IF ERROR` in Amiga scripts)
- Bump `filename` buffers from 256 to 1024 bytes for long host paths
- Suppress `-Wall` warnings: extra parens on assignments in conditionals
- Add `?` usage handler to `host-shell` for consistency with other tools
- Update `host-multiview` help text to reflect URL support
- Add `-Wall -Wextra` warning flags and `make debug` target to Makefile

## Test plan
- [ ] `host-run` with file paths containing single quotes (quoting fix)
- [ ] `host-run <command>` — verify exit code propagates (`IF WARN` / `IF ERROR`)
- [ ] `host-multiview ?` — verify updated help text
- [ ] `host-shell ?` — verify usage output
- [ ] `make debug` — builds with `-DDEBUG -g`
- [ ] `make clean && make` — clean build with no warnings