### PR TITLE
Centralize version strings and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,22 @@
 # m68k-amigaos-gcc -Isrc -noixemul -fomit-frame-pointer -Os -std=c99 -o host-run src/host-run.c
 all: host-run host-multiview host-shell
 
+VERSION		= 1.9
+DATE		= 2025-12-26
+
 CC			= m68k-amigaos-gcc
 INCLUDES	= -Isrc
 CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99 -Wall -Wextra
+VERFLAGS	= -DVERSION_STR="\"$(VERSION)\"" -DDATE_STR="\"$(DATE)\""
 
 host-run: src/host-run.c
-	$(CC) $(CFLAGS) $(INCLUDES) src/host-run.c -o $@
+	$(CC) $(CFLAGS) $(VERFLAGS) $(INCLUDES) src/host-run.c -o $@
 
 host-multiview: src/host-multiview.c
-	$(CC) $(CFLAGS) $(INCLUDES) src/host-multiview.c -o $@
+	$(CC) $(CFLAGS) $(VERFLAGS) $(INCLUDES) src/host-multiview.c -o $@
 
 host-shell: src/host-shell.c
-	$(CC) $(CFLAGS) $(INCLUDES) src/host-shell.c -o $@
+	$(CC) $(CFLAGS) $(VERFLAGS) $(INCLUDES) src/host-shell.c -o $@
 
 debug: CFLAGS += -DDEBUG -g
 debug: clean all

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ host-run <command> [arguments...]
 ```
 
 ### 2. host-multiview
-**Open files with the default host application.**
-Think of this as an "Open with..." command for the Amiga. It sends a file to the host system, which then opens it using the default associated application (e.g., VLC for videos, Preview for images).
+**Open files or URLs with the default host application.**
+Think of this as an "Open with..." command for the Amiga. It sends a file or URL to the host system, which then opens it using the default associated application (e.g., VLC for videos, Preview for images, your browser for URLs).
 -   **Cross-Platform**: Works natively on **Linux** (via `xdg-open`) and **macOS** (via `open`).
 -   **Seamless**: Perfect for integration with DefIcons to open media files or documents on the host.
 
 **Usage:**
 ```shell
-host-multiview <filename>
+host-multiview <filename|URL> [filename2|URL2 ...]
 ```
 
 ### 3. host-shell
@@ -56,11 +56,14 @@ host-shell
 ## Examples
 
 ### Web Browsing
-Open a URL in the host's default browser:
+Open a URL in the host's default browser (works on both Linux and macOS):
 ```shell
-host-run xdg-open "https://github.com/BlitterStudio/amiberry"
+host-multiview https://github.com/BlitterStudio/amiberry
 ```
-*(On macOS, use `host-run open ...` or just use `host-multiview` which handles both!)*
+Or using `host-run` with the platform-specific command:
+```shell
+host-run xdg-open https://github.com/BlitterStudio/amiberry
+```
 
 ### Playing Media
 Play a video file located on an Amiga partition using the host's media player:
@@ -81,11 +84,16 @@ Make AmigaOS automatically open `.mkv` files on the host:
 
 ## Building
 
-This project is built using **GitHub Actions**. Every push to `main` or a version tag triggers a build using the `amigadev/crosstools:m68k-amigaos` Docker image.
+This project is built using **GitHub Actions**. Every push to `master` or a version tag triggers a build using the `amigadev/crosstools:m68k-amigaos` Docker image.
 
-To build locally (requires Docker):
+To build locally (requires the m68k-amigaos cross-compiler):
 ```shell
 make all
+```
+
+To build with debug output enabled:
+```shell
+make debug
 ```
 
 ## License

--- a/src/host-multiview.c
+++ b/src/host-multiview.c
@@ -3,13 +3,13 @@
 #include <stdlib.h>
 #include "uae_pragmas.h"
 
-static const char __ver[] = "$VER: Host-MultiView v" VERSION_STR " (" DATE_STR ")";
+static const char version[] = "$VER: Host-MultiView v" VERSION_STR " (" DATE_STR ")";
 
 int print_usage()
 {
     printf("Host-MultiView v%s\n", VERSION_STR);
     printf("Host-MultiView is a command line tool to open files or URLs with the host default handler, from within UAE.\n");
-    printf("%s\nUsage: host-multiview <filename|URL> [filename2|URL2 ...]\n", __ver);
+    printf("%s\nUsage: host-multiview <filename|URL> [filename2|URL2 ...]\n", version);
     return 0;
 }
 

--- a/src/host-multiview.c
+++ b/src/host-multiview.c
@@ -3,11 +3,11 @@
 #include <stdlib.h>
 #include "uae_pragmas.h"
 
-static const char __ver[40] = "$VER: Host-MultiView v1.9 (2025-12-26)";
+static const char __ver[] = "$VER: Host-MultiView v" VERSION_STR " (" DATE_STR ")";
 
 int print_usage()
 {
-    printf("Host-MultiView v1.9\n");
+    printf("Host-MultiView v%s\n", VERSION_STR);
     printf("Host-MultiView is a command line tool to open files or URLs with the host default handler, from within UAE.\n");
     printf("%s\nUsage: host-multiview <filename|URL> [filename2|URL2 ...]\n", __ver);
     return 0;

--- a/src/host-run.c
+++ b/src/host-run.c
@@ -3,13 +3,13 @@
 #include <stdlib.h>
 #include "uae_pragmas.h"
 
-static const char __ver[40] = "$VER: Host-Run v1.9 (2025-12-26)";
+static const char __ver[] = "$VER: Host-Run v" VERSION_STR " (" DATE_STR ")";
 
 #define MAX_CMD_LEN 4096
 
 int print_usage()
 {
-    printf("Host-Run v1.9\n");
+    printf("Host-Run v%s\n", VERSION_STR);
     printf("Host-Run is a command line tool to run host commands from within UAE.\n");
     printf("%s\nUsage: host-run <command> <argument1> <argument2> ...\n", __ver);
     return 0;

--- a/src/host-run.c
+++ b/src/host-run.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include "uae_pragmas.h"
 
-static const char __ver[] = "$VER: Host-Run v" VERSION_STR " (" DATE_STR ")";
+static const char version[] = "$VER: Host-Run v" VERSION_STR " (" DATE_STR ")";
 
 #define MAX_CMD_LEN 4096
 
@@ -11,7 +11,7 @@ int print_usage()
 {
     printf("Host-Run v%s\n", VERSION_STR);
     printf("Host-Run is a command line tool to run host commands from within UAE.\n");
-    printf("%s\nUsage: host-run <command> <argument1> <argument2> ...\n", __ver);
+    printf("%s\nUsage: host-run <command> <argument1> <argument2> ...\n", version);
     return 0;
 }
 

--- a/src/host-shell.c
+++ b/src/host-shell.c
@@ -8,7 +8,7 @@
 
 #define OUTBUFSIZE 4095
 
-static const char version[] = "$VER: Host-Shell v1.9 (2025-12-26)";
+static const char version[] = "$VER: Host-Shell v" VERSION_STR " (" DATE_STR ")";
 char outbuf[OUTBUFSIZE + 1];
 
 int main(int argc, char *argv[])
@@ -28,10 +28,9 @@ int main(int argc, char *argv[])
 
     if (argc == 2 && strcmp(argv[1], "?") == 0)
     {
-        printf("Host-Shell v1.9\n");
+        printf("Host-Shell v%s\n", VERSION_STR);
         printf("Host-Shell opens an interactive terminal session on the host system.\n");
-        printf("$VER: Host-Shell v1.9 (2025-12-26)\n");
-        printf("Usage: host-shell [command]\n");
+        printf("%s\nUsage: host-shell [command]\n", version);
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- Version and date are now defined once in the Makefile (`VERSION` and `DATE` variables), passed to all tools via `-DVERSION_STR` and `-DDATE_STR` — version bumps are now a one-line change
- Removed hardcoded version strings from all three source files
- Updated README:
  - `host-multiview` documented as supporting URLs (not just files)
  - Web browsing example leads with `host-multiview` as the cross-platform option
  - Fixed branch name reference (`main` -> `master`)
  - Added `make debug` instructions

## Test plan
- [ ] `make clean && make` — verify all tools compile with version from Makefile
- [ ] `host-run ?` / `host-multiview ?` / `host-shell ?` — verify version output matches Makefile
- [ ] Change `VERSION` in Makefile, rebuild, confirm all tools pick up the new version