### PR TITLE
Cover host-info command builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 TOOLS		= host-run host-multiview host-shell host-path host-reveal host-notify host-edit host-clip host-info
 TESTS		= tests/test_host_common.out tests/test_host_command_builders.out tests/test_host_edit_command.out
-COMMON_HEADERS	= src/host_common.h src/host_path.h src/host_capture.h src/host_clip_command.h src/host_edit_command.h src/host_notify_command.h src/host_reveal_command.h src/uae_pragmas.h
+COMMON_HEADERS	= src/host_common.h src/host_path.h src/host_capture.h src/host_clip_command.h src/host_edit_command.h src/host_info_command.h src/host_notify_command.h src/host_reveal_command.h src/uae_pragmas.h
 PACKAGE		= Host-Tools-$(VERSION).lha
 
 .PHONY: all test debug package clean
@@ -21,7 +21,7 @@ ifeq ($(origin CC),default)
 CC			= m68k-amigaos-gcc
 endif
 INCLUDES	= -Isrc
-CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99 -Wall -Wextra
+CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99 -Wall -Wextra -Wstrict-prototypes
 VERFLAGS	= -DVERSION_STR="\"$(VERSION)\"" -DDATE_STR="\"$(DATE)\""
 HOST_CC		?= $(shell command -v x86_64-linux-gnu-gcc 2>/dev/null || command -v cc 2>/dev/null || printf cc)
 HOST_NATIVE_FLAGS = $(if $(findstring x86_64-linux-gnu-gcc,$(notdir $(HOST_CC))),-B/usr/bin/x86_64-linux-gnu- -fuse-ld=bfd,)
@@ -57,7 +57,7 @@ host-info: src/host-info.c $(COMMON_HEADERS)
 tests/test_host_common.out: tests/test_host_common.c src/host_common.h
 	$(HOST_CC) $(HOST_NATIVE_FLAGS) $(HOST_CFLAGS) tests/test_host_common.c -o $@
 
-tests/test_host_command_builders.out: tests/test_host_command_builders.c src/host_clip_command.h src/host_common.h src/host_notify_command.h src/host_reveal_command.h
+tests/test_host_command_builders.out: tests/test_host_command_builders.c src/host_clip_command.h src/host_common.h src/host_info_command.h src/host_notify_command.h src/host_reveal_command.h
 	$(HOST_CC) $(HOST_NATIVE_FLAGS) $(HOST_CFLAGS) tests/test_host_command_builders.c -o $@
 
 tests/test_host_edit_command.out: tests/test_host_edit_command.c src/host_edit_command.h src/host_common.h

--- a/src/host-clip.c
+++ b/src/host-clip.c
@@ -10,7 +10,7 @@
 
 static const char version[] = "$VER: Host-Clip v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Clip v%s\n", VERSION_STR);
     printf("Host-Clip copies text to or pastes text from the host clipboard.\n");

--- a/src/host-edit.c
+++ b/src/host-edit.c
@@ -10,7 +10,7 @@
 
 static const char version[] = "$VER: Host-Edit v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Edit v%s\n", VERSION_STR);
     printf("Host-Edit opens files in the host desktop editor.\n");

--- a/src/host-info.c
+++ b/src/host-info.c
@@ -6,10 +6,11 @@
 #include <stdio.h>
 #include <string.h>
 #include "host_capture.h"
+#include "host_info_command.h"
 
 static const char version[] = "$VER: Host-Info v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Info v%s\n", VERSION_STR);
     printf("Host-Info prints basic host integration details.\n");
@@ -19,27 +20,6 @@ int print_usage()
 
 int main(int argc, char *argv[])
 {
-    static const char command[] =
-        "printf 'OS: '; uname -srm 2>/dev/null || printf 'unknown\\n'; "
-        "printf 'User: '; id -un 2>/dev/null || whoami 2>/dev/null || printf 'unknown\\n'; "
-        "printf 'Shell: %s\\n' \"${SHELL:-unknown}\"; "
-        "printf 'Editor: '; "
-        "if [ \"$(uname -s)\" = Darwin ] && command -v open >/dev/null 2>&1; then echo 'open -t'; "
-        "elif command -v xdg-mime >/dev/null 2>&1 && command -v gtk-launch >/dev/null 2>&1; then desktop_file=$(xdg-mime query default text/plain 2>/dev/null); "
-        "if [ -n \"$desktop_file\" ]; then printf 'gtk-launch %s\\n' \"$desktop_file\"; "
-        "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; "
-        "elif [ -n \"${VISUAL:-${EDITOR:-}}\" ]; then printf '%s\\n' \"${VISUAL:-${EDITOR:-}}\"; else echo unavailable; fi; "
-        "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; "
-        "elif [ -n \"${VISUAL:-${EDITOR:-}}\" ]; then printf '%s\\n' \"${VISUAL:-${EDITOR:-}}\"; else echo unavailable; fi; "
-        "printf 'Opener: '; "
-        "if [ \"$(uname -s)\" = Darwin ] && command -v open >/dev/null 2>&1; then echo open; "
-        "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; else echo unavailable; fi; "
-        "printf 'Clipboard: '; "
-        "if command -v pbcopy >/dev/null 2>&1 && command -v pbpaste >/dev/null 2>&1; then echo pbcopy/pbpaste; "
-        "elif command -v wl-copy >/dev/null 2>&1 && command -v wl-paste >/dev/null 2>&1; then echo wl-clipboard; "
-        "elif command -v xclip >/dev/null 2>&1; then echo xclip; "
-        "elif command -v xsel >/dev/null 2>&1; then echo xsel; else echo unavailable; fi";
-
     if (!InitUAEResource())
     {
         printf("UAEResource not found!\n");
@@ -57,5 +37,5 @@ int main(int argc, char *argv[])
         return print_usage();
     }
 
-    return host_print_command_output(command);
+    return host_print_command_output(HOST_INFO_COMMAND);
 }

--- a/src/host-multiview.c
+++ b/src/host-multiview.c
@@ -10,7 +10,7 @@
 
 static const char version[] = "$VER: Host-MultiView v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-MultiView v%s\n", VERSION_STR);
     printf("Host-MultiView is a command line tool to open files or URLs with the host default handler, from within UAE.\n");

--- a/src/host-notify.c
+++ b/src/host-notify.c
@@ -10,7 +10,7 @@
 
 static const char version[] = "$VER: Host-Notify v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Notify v%s\n", VERSION_STR);
     printf("Host-Notify sends a desktop notification on the host.\n");

--- a/src/host-path.c
+++ b/src/host-path.c
@@ -9,7 +9,7 @@
 
 static const char version[] = "$VER: Host-Path v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Path v%s\n", VERSION_STR);
     printf("Host-Path prints host paths for Amiga paths.\n");

--- a/src/host-reveal.c
+++ b/src/host-reveal.c
@@ -11,7 +11,7 @@
 
 static const char version[] = "$VER: Host-Reveal v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Reveal v%s\n", VERSION_STR);
     printf("Host-Reveal reveals files in the host file manager.\n");

--- a/src/host-run.c
+++ b/src/host-run.c
@@ -10,7 +10,7 @@
 
 static const char version[] = "$VER: Host-Run v" VERSION_STR " (" DATE_STR ")";
 
-int print_usage()
+static int print_usage(void)
 {
     printf("Host-Run v%s\n", VERSION_STR);
     printf("Host-Run is a command line tool to run host commands from within UAE.\n");

--- a/src/host_info_command.h
+++ b/src/host_info_command.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef HOST_INFO_COMMAND_H
+#define HOST_INFO_COMMAND_H
+
+#define HOST_INFO_COMMAND \
+    "printf 'OS: '; uname -srm 2>/dev/null || printf 'unknown\\n'; " \
+    "printf 'User: '; id -un 2>/dev/null || whoami 2>/dev/null || printf 'unknown\\n'; " \
+    "printf 'Shell: %s\\n' \"${SHELL:-unknown}\"; " \
+    "printf 'Editor: '; " \
+    "if [ \"$(uname -s)\" = Darwin ] && command -v open >/dev/null 2>&1; then echo 'open -t'; " \
+    "elif command -v xdg-mime >/dev/null 2>&1 && command -v gtk-launch >/dev/null 2>&1; then desktop_file=$(xdg-mime query default text/plain 2>/dev/null); " \
+    "if [ -n \"$desktop_file\" ]; then printf 'gtk-launch %s\\n' \"$desktop_file\"; " \
+    "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; " \
+    "elif [ -n \"${VISUAL:-${EDITOR:-}}\" ]; then printf '%s\\n' \"${VISUAL:-${EDITOR:-}}\"; else echo unavailable; fi; " \
+    "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; " \
+    "elif [ -n \"${VISUAL:-${EDITOR:-}}\" ]; then printf '%s\\n' \"${VISUAL:-${EDITOR:-}}\"; else echo unavailable; fi; " \
+    "printf 'Opener: '; " \
+    "if [ \"$(uname -s)\" = Darwin ] && command -v open >/dev/null 2>&1; then echo open; " \
+    "elif command -v xdg-open >/dev/null 2>&1; then echo xdg-open; else echo unavailable; fi; " \
+    "printf 'Clipboard: '; " \
+    "if command -v pbcopy >/dev/null 2>&1 && command -v pbpaste >/dev/null 2>&1; then echo pbcopy/pbpaste; " \
+    "elif command -v wl-copy >/dev/null 2>&1 && command -v wl-paste >/dev/null 2>&1; then echo wl-clipboard; " \
+    "elif command -v xclip >/dev/null 2>&1; then echo xclip; " \
+    "elif command -v xsel >/dev/null 2>&1; then echo xsel; else echo unavailable; fi"
+
+#endif

--- a/src/uae_pragmas.h
+++ b/src/uae_pragmas.h
@@ -143,11 +143,11 @@ static int UAE_UNUSED Minimize(void)
 {
     return calltrap(68);
 }
-static int UAE_UNUSED ExecuteNativeCode()
+static int UAE_UNUSED ExecuteNativeCode(void)
 {
     return calltrap(69);
 }
-static int UAE_UNUSED UnprotectMapRom()
+static int UAE_UNUSED UnprotectMapRom(void)
 {
     return calltrap(80);
 }
@@ -159,7 +159,7 @@ static int UAE_UNUSED EmuConfigModify(int mode, UBYTE *parms, ULONG size, ULONG 
 {
     return calltrap(82, mode, parms, size, out, outsize);
 }
-static int UAE_UNUSED IsMMKeyboard()
+static int UAE_UNUSED IsMMKeyboard(void)
 {
     return calltrap(83);
 }
@@ -167,7 +167,7 @@ static int UAE_UNUSED NativeDosOp(ULONG mode, ULONG lock, ULONG out, ULONG outsi
 {
     return calltrap(85, mode, lock, out, outsize);
 }
-static int UAE_UNUSED GetCpuRate()
+static int UAE_UNUSED GetCpuRate(void)
 {
     return calltrap(87);
 }

--- a/tests/test_host_command_builders.c
+++ b/tests/test_host_command_builders.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "host_clip_command.h"
+#include "host_info_command.h"
 #include "host_notify_command.h"
 #include "host_reveal_command.h"
 
@@ -94,6 +95,16 @@ static void test_clip_paste_command(void)
     require_shell_syntax(HOST_CLIP_PASTE_COMMAND);
 }
 
+static void test_info_command(void)
+{
+    require_contains(HOST_INFO_COMMAND, "printf 'OS: '");
+    require_contains(HOST_INFO_COMMAND, "printf 'Editor: '");
+    require_contains(HOST_INFO_COMMAND, "xdg-mime query default text/plain");
+    require_contains(HOST_INFO_COMMAND, "printf 'Opener: '");
+    require_contains(HOST_INFO_COMMAND, "printf 'Clipboard: '");
+    require_shell_syntax(HOST_INFO_COMMAND);
+}
+
 static void test_small_buffer_failures(void)
 {
     char command[32];
@@ -117,6 +128,7 @@ int main(void)
     test_notify_command();
     test_clip_copy_command();
     test_clip_paste_command();
+    test_info_command();
     test_small_buffer_failures();
     return 0;
 }


### PR DESCRIPTION
## Summary
- extract the host-info shell command into a testable command header
- add command-builder coverage for the host-info shell snippet
- enable strict prototype warnings for target builds
- convert local no-argument helpers to explicit void prototypes

## Validation
- make -B test HOST_CFLAGS="-std=c99 -Wall -Wextra -Wstrict-prototypes -Werror -Isrc"
- git diff --check
- make -n all
