### PR TITLE
Add UAE MHI MP3 decoder library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ docs/superpowers/
 build/
 drivers/ahi/package/
 drivers/ahi/package-v2/
+drivers/mhi/build/
+drivers/mhi/package/
 dist/
 release/
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ AHI_FILES	= $(AHI_AUDIO) $(AHI_MODE)
 AHI_V2_AUDIO	= drivers/ahi/package-v2/Devs/AHI/uaesnd.audio
 AHI_V2_MODE	= drivers/ahi/package-v2/Devs/AudioModes/UAESND
 AHI_V2_FILES	= $(AHI_V2_AUDIO) $(AHI_V2_MODE)
+MHI_LIBRARY	= drivers/mhi/package/Libs/MHI/mhiuae.library
+MHI_FILES	= $(MHI_LIBRARY)
 AHI_SOURCES	= drivers/ahi/Makefile \
 	drivers/ahi/src/v1/uae.audio.asm \
 	drivers/ahi/src/v1/UAE.asm \
@@ -29,6 +31,11 @@ AHI_SOURCES	= drivers/ahi/Makefile \
 AHI_V2_SOURCES	= drivers/ahi/Makefile \
 	drivers/ahi/src/v2/uaesnd.audio.asm \
 	drivers/ahi/src/v2/UAESND.asm
+MHI_SOURCES	= drivers/mhi/Makefile \
+	drivers/mhi/src/mhiuae.h \
+	drivers/mhi/src/mhiuae_startup.c \
+	drivers/mhi/src/mhiuae.c \
+	src/uae_pragmas.h
 HELP_GUIDE	= package/Help/Host-Tools.guide
 DRAWER_ICON	= package/icons/drawer.info
 HELP_ICON	= package/icons/Help.info
@@ -37,9 +44,9 @@ README_ICON	= package/icons/readme.info
 GUIDE_ICON	= package/icons/guide.info
 
 .SUFFIXES:
-.PHONY: all test debug package package-dir ahi ahi-v2 clean
+.PHONY: all test debug package package-dir ahi ahi-v2 mhi clean
 
-all: $(TOOLS) $(AHI_FILES) $(AHI_V2_FILES)
+all: $(TOOLS) $(AHI_FILES) $(AHI_V2_FILES) $(MHI_FILES)
 test: $(TESTS)
 	@for test in $(TESTS); do \
 		case "$$test" in \
@@ -113,11 +120,16 @@ ahi: $(AHI_FILES)
 
 ahi-v2: $(AHI_V2_FILES)
 
+mhi: $(MHI_FILES)
+
 $(AHI_FILES): $(AHI_SOURCES)
 	$(MAKE) -C drivers/ahi VERSION=$(VERSION) DATE=$(DATE)
 
 $(AHI_V2_FILES): $(AHI_V2_SOURCES)
 	$(MAKE) -C drivers/ahi VERSION=$(VERSION) DATE=$(DATE) ahi-v2
+
+$(MHI_FILES): $(MHI_SOURCES)
+	$(MAKE) -C drivers/mhi VERSION=$(VERSION) DATE=$(DATE)
 
 package-dir: all package/Install $(HELP_GUIDE) $(DRAWER_ICON) $(HELP_ICON) $(INSTALL_ICON) $(README_ICON) $(GUIDE_ICON)
 	rm -rf $(PACKAGE_STAGE) $(PACKAGE_DIR)/$(PACKAGE_ROOT).info
@@ -142,6 +154,10 @@ package-dir: all package/Install $(HELP_GUIDE) $(DRAWER_ICON) $(HELP_ICON) $(INS
 		cp $(AHI_V2_AUDIO) $(PACKAGE_STAGE)/Devs/AHI/uaesnd.audio; \
 		cp $(AHI_V2_MODE) $(PACKAGE_STAGE)/Devs/AudioModes/UAESND; \
 	fi
+	if [ -f $(MHI_LIBRARY) ]; then \
+		mkdir -p $(PACKAGE_STAGE)/Libs/MHI; \
+		cp $(MHI_LIBRARY) $(PACKAGE_STAGE)/Libs/MHI/mhiuae.library; \
+	fi
 
 package: package-dir
 	rm -f $(PACKAGE)
@@ -150,3 +166,4 @@ package: package-dir
 clean:
 	rm -f $(TOOLS) $(TEST_BINS)
 	$(MAKE) -C drivers/ahi clean
+	$(MAKE) -C drivers/mhi clean

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ All tools follow AmigaDOS conventions: `0` on success, `10` (`RETURN_ERROR`) whe
 2.  Extract the `Host-Tools-<version>.lha` archive.
 3.  Open the `Host-Tools` drawer and run `Install`.
 
-The installer shows a component checklist for the command tools, AmigaGuide documentation, and the UAE and UAESND AHI audio drivers. Before replacing an existing versioned file, it shows the installed and package versions and asks whether to replace or skip it. Files without version strings are still checked for existence and ask before overwrite. It does not edit startup files, system settings, AHI preferences, or existing driver configuration.
+The installer shows a component checklist for the command tools, AmigaGuide documentation, the UAE and UAESND AHI audio drivers, and the UAE MHI MP3 decoder library. Before replacing an existing versioned file, it shows the installed and package versions and asks whether to replace or skip it. Files without version strings are still checked for existence and ask before overwrite. It does not edit startup files, system settings, AHI preferences, or existing driver configuration.
 
-For manual installation, copy the binaries (`host-run`, `host-multiview`, `host-shell`, `host-path`, `host-reveal`, `host-notify`, `host-edit`, `host-clip`, `host-info`, `host-download`, `host-env`) from the package `C` drawer to `C:` or anywhere in your system path. To install the UAE AHI driver manually, copy `Devs/AHI/uae.audio` to `DEVS:AHI/` and `Devs/AudioModes/UAE` to `DEVS:AudioModes/`. To install the UAESND AHI driver manually, copy `Devs/AHI/uaesnd.audio` to `DEVS:AHI/` and `Devs/AudioModes/UAESND` to `DEVS:AudioModes/`. The UAESND driver plays each AHI channel through a hardware audio stream and requires the UAESND sound board to be enabled in the Amiberry configuration.
+For manual installation, copy the binaries (`host-run`, `host-multiview`, `host-shell`, `host-path`, `host-reveal`, `host-notify`, `host-edit`, `host-clip`, `host-info`, `host-download`, `host-env`) from the package `C` drawer to `C:` or anywhere in your system path. To install the UAE AHI driver manually, copy `Devs/AHI/uae.audio` to `DEVS:AHI/` and `Devs/AudioModes/UAE` to `DEVS:AudioModes/`. To install the UAESND AHI driver manually, copy `Devs/AHI/uaesnd.audio` to `DEVS:AHI/` and `Devs/AudioModes/UAESND` to `DEVS:AudioModes/`. To install the UAE MHI MP3 decoder manually, copy `Libs/MHI/mhiuae.library` to `LIBS:MHI/`. The UAESND driver plays each AHI channel through a hardware audio stream and requires the UAESND sound board to be enabled in the Amiberry configuration. The MHI library is independent of the selected AHI output mode and forwards MP3 decoding to Amiberry through `uae.resource`.
 
 ## Examples
 
@@ -213,7 +213,7 @@ To build a release archive:
 make package
 ```
 
-The package target creates `Host-Tools-<version>.lha`, containing a structured `Host-Tools` drawer with the Installer script, command tools, README, AmigaGuide documentation, and the UAE and UAESND AHI driver files.
+The package target creates `Host-Tools-<version>.lha`, containing a structured `Host-Tools` drawer with the Installer script, command tools, README, AmigaGuide documentation, the UAE and UAESND AHI driver files, and the UAE MHI MP3 decoder library.
 
 Native package builds also require `lha`. The Docker build image contains this tool.
 

--- a/drivers/ahi/Makefile
+++ b/drivers/ahi/Makefile
@@ -4,10 +4,11 @@
 VERSION		?= 2.4
 DATE		?= 2026-06-10
 
-ifeq ($(origin VASMM68K),default)
-VASMM68K	= vasmm68k_mot
+VASMM68K_FALLBACK := $(shell command -v vasmm68k_mot 2>/dev/null || { test -x /opt/m68k-amigaos/bin/vasmm68k_mot && printf /opt/m68k-amigaos/bin/vasmm68k_mot; } || printf vasmm68k_mot)
+ifeq ($(origin VASMM68K),undefined)
+VASMM68K	:= $(VASMM68K_FALLBACK)
 endif
-VASMM68K_CMD	= $(if $(VASMM68K),$(VASMM68K),vasmm68k_mot)
+VASMM68K_CMD	= $(if $(strip $(VASMM68K)),$(VASMM68K),$(VASMM68K_FALLBACK))
 
 BUILD_DIR	= build
 AHI_PACKAGE_DIR	= package

--- a/drivers/mhi/Makefile
+++ b/drivers/mhi/Makefile
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+VERSION		?= 2.4
+DATE		?= 2026-06-10
+VERSION_WORDS	= $(subst ., ,$(VERSION))
+LIB_VERSION	= $(word 1,$(VERSION_WORDS))
+LIB_REVISION	= $(word 2,$(VERSION_WORDS))
+LIB_REVISION	:= $(if $(LIB_REVISION),$(LIB_REVISION),0)
+
+ifeq ($(origin CC),default)
+CC		= m68k-amigaos-gcc
+endif
+
+BUILD_DIR	= build
+PACKAGE_DIR	= package
+LIB_OUT		= $(PACKAGE_DIR)/Libs/MHI/mhiuae.library
+SOURCES		= src/mhiuae_startup.c src/mhiuae.c
+HEADERS		= src/mhi_abi.h src/mhiuae.h ../../src/uae_pragmas.h
+CFLAGS		= -mcpu=68020 -noixemul -Os -fomit-frame-pointer -std=c99 -Wall -Wextra -Wstrict-prototypes -I../../src
+VERFLAGS	= -DVERSION_STR="\"$(VERSION)\"" -DDATE_STR="\"$(DATE)\"" -DLIB_VERSION=$(LIB_VERSION) -DLIB_REVISION=$(LIB_REVISION)
+LDFLAGS		= -nostartfiles
+
+.SUFFIXES:
+.PHONY: all clean
+
+all: $(LIB_OUT)
+
+$(BUILD_DIR)/mhiuae.library: $(SOURCES) $(HEADERS) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(VERFLAGS) $(LDFLAGS) $(SOURCES) -o $@
+
+$(LIB_OUT): $(BUILD_DIR)/mhiuae.library | $(PACKAGE_DIR)/Libs/MHI
+	cp $< $@
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(PACKAGE_DIR)/Libs/MHI:
+	mkdir -p $@
+
+clean:
+	rm -rf $(BUILD_DIR) $(PACKAGE_DIR)

--- a/drivers/mhi/src/mhi_abi.h
+++ b/drivers/mhi/src/mhi_abi.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef MHI_ABI_H
+#define MHI_ABI_H
+
+#define MHIF_PLAYING 0
+#define MHIF_STOPPED 1
+#define MHIF_OUT_OF_DATA 2
+#define MHIF_PAUSED 3
+
+#define MHIF_UNSUPPORTED 0
+#define MHIF_SUPPORTED 1
+#define MHIF_FALSE 0
+#define MHIF_TRUE 1
+
+#define MHIQ_CAPABILITIES 0
+#define MHIQ_MPEG1 1
+#define MHIQ_MPEG2 2
+#define MHIQ_MPEG25 3
+
+#define MHIQ_LAYER3 12
+
+#define MHIQ_VARIABLE_BITRATE 20
+#define MHIQ_JOINT_STEREO 21
+
+#define MHIQ_VOLUME_CONTROL 40
+#define MHIQ_PANNING_CONTROL 41
+
+#define MHIQ_DECODER_NAME 1000
+#define MHIQ_DECODER_VERSION 1001
+#define MHIQ_AUTHOR 1002
+
+#define MHIQ_IS_HARDWARE 1010
+#define MHIQ_IS_68K 1011
+#define MHIQ_IS_PPC 1012
+
+#define MHIP_VOLUME 0
+#define MHIP_PANNING 1
+
+#endif /* MHI_ABI_H */

--- a/drivers/mhi/src/mhiuae.c
+++ b/drivers/mhi/src/mhiuae.c
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#define __USE_SYSBASE
+
+#include <exec/memory.h>
+#include <proto/exec.h>
+
+#include "mhiuae.h"
+#include "uae_pragmas.h"
+
+static const char decoder_version[] __attribute__((used)) = MHIUAE_LIBRARY_NAME " " VERSION_STR " (" DATE_STR ")";
+
+BOOL mhiuae_open_uae(void)
+{
+    return InitUAEResource() ? TRUE : FALSE;
+}
+
+void mhiuae_close_uae(void)
+{
+}
+
+static struct MHIUAEPlayer *valid_player(APTR handle)
+{
+    return (struct MHIUAEPlayer *)handle;
+}
+
+APTR i_MHIAllocDecoder(struct Task *task __asm("a0"), ULONG sigmask __asm("d0"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player;
+    ULONG host_handle;
+
+    if (base->allocated_decoders != 0) {
+        return NULL;
+    }
+
+    if (task == NULL) {
+        task = FindTask(NULL);
+    }
+
+    host_handle = UaeMHIAlloc(task, sigmask);
+    if (host_handle == 0) {
+        return NULL;
+    }
+
+    player = AllocVec(sizeof(*player), MEMF_PUBLIC | MEMF_CLEAR);
+    if (player == NULL) {
+        UaeMHIFree(host_handle);
+        return NULL;
+    }
+
+    player->task = task;
+    player->sigmask = sigmask;
+    player->host_handle = host_handle;
+    player->status = MHIF_STOPPED;
+    base->allocated_decoders++;
+    return player;
+}
+
+void i_MHIFreeDecoder(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    if (player == NULL) {
+        return;
+    }
+
+    UaeMHIFree(player->host_handle);
+    if (base->allocated_decoders > 0) {
+        base->allocated_decoders--;
+    }
+    FreeVec(player);
+}
+
+BOOL i_MHIQueueBuffer(APTR handle __asm("a3"), APTR buffer __asm("a0"), ULONG size __asm("d0"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+    ULONG queued;
+
+    (void)base;
+    if (player == NULL || buffer == NULL || size == 0) {
+        return FALSE;
+    }
+
+    queued = UaeMHIQueue(player->host_handle, buffer, size, (ULONG)buffer);
+    if (queued && player->task != NULL && player->sigmask != 0) {
+        Signal(player->task, player->sigmask);
+    }
+    return queued ? TRUE : FALSE;
+}
+
+APTR i_MHIGetEmpty(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player == NULL) {
+        return NULL;
+    }
+    return (APTR)UaeMHIGetEmpty(player->host_handle);
+}
+
+UBYTE i_MHIGetStatus(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player == NULL) {
+        return MHIF_STOPPED;
+    }
+    player->status = (UBYTE)UaeMHIStatus(player->host_handle);
+    return player->status;
+}
+
+void i_MHIPlay(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player != NULL && UaeMHIPlay(player->host_handle)) {
+        player->status = MHIF_PLAYING;
+    }
+}
+
+void i_MHIStop(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player != NULL && UaeMHIStop(player->host_handle)) {
+        player->status = MHIF_STOPPED;
+    }
+}
+
+void i_MHIPause(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player != NULL && UaeMHIPause(player->host_handle)) {
+        player->status = MHIF_PAUSED;
+    }
+}
+
+ULONG i_MHIQuery(ULONG query __asm("d1"), struct MHIUAEBase *base __asm("a6"))
+{
+    (void)base;
+    switch (query) {
+        case MHIQ_CAPABILITIES:
+            return (ULONG)MHIUAE_CAPABILITIES;
+        case MHIQ_DECODER_NAME:
+            return (ULONG)MHIUAE_DECODER_NAME;
+        case MHIQ_DECODER_VERSION:
+            return (ULONG)decoder_version;
+        case MHIQ_AUTHOR:
+            return (ULONG)MHIUAE_AUTHOR;
+        case MHIQ_IS_HARDWARE:
+            return MHIF_TRUE;
+        case MHIQ_IS_68K:
+        case MHIQ_IS_PPC:
+            return MHIF_FALSE;
+        case MHIQ_MPEG1:
+        case MHIQ_MPEG2:
+        case MHIQ_MPEG25:
+        case MHIQ_LAYER3:
+        case MHIQ_VARIABLE_BITRATE:
+        case MHIQ_JOINT_STEREO:
+        case MHIQ_VOLUME_CONTROL:
+        case MHIQ_PANNING_CONTROL:
+            return MHIF_SUPPORTED;
+        default:
+            return MHIF_UNSUPPORTED;
+    }
+}
+
+void i_MHISetParam(APTR handle __asm("a3"), UWORD param __asm("d0"), ULONG value __asm("d1"), struct MHIUAEBase *base __asm("a6"))
+{
+    struct MHIUAEPlayer *player = valid_player(handle);
+
+    (void)base;
+    if (player != NULL) {
+        UaeMHISetParam(player->host_handle, param, value);
+    }
+}

--- a/drivers/mhi/src/mhiuae.h
+++ b/drivers/mhi/src/mhiuae.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef MHIUAE_H
+#define MHIUAE_H
+
+#include <exec/libraries.h>
+#include <exec/tasks.h>
+#include <exec/types.h>
+
+#include "mhi_abi.h"
+
+#define MHIUAE_LIBRARY_NAME "mhiuae.library"
+#define MHIUAE_DECODER_NAME "UAE MP3 decoder"
+#define MHIUAE_AUTHOR "Amiberry"
+#define MHIUAE_CAPABILITIES "audio/mpeg audio/mp3"
+
+struct MHIUAEBase {
+    struct Library lib;
+    BPTR seg_list;
+    struct ExecBase *sys_base;
+    ULONG allocated_decoders;
+};
+
+struct MHIUAEPlayer {
+    struct Task *task;
+    ULONG sigmask;
+    ULONG host_handle;
+    UBYTE status;
+};
+
+BOOL mhiuae_open_uae(void);
+void mhiuae_close_uae(void);
+
+APTR i_MHIAllocDecoder(struct Task *task __asm("a0"), ULONG sigmask __asm("d0"), struct MHIUAEBase *base __asm("a6"));
+void i_MHIFreeDecoder(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+BOOL i_MHIQueueBuffer(APTR handle __asm("a3"), APTR buffer __asm("a0"), ULONG size __asm("d0"), struct MHIUAEBase *base __asm("a6"));
+APTR i_MHIGetEmpty(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+UBYTE i_MHIGetStatus(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+void i_MHIPlay(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+void i_MHIStop(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+void i_MHIPause(APTR handle __asm("a3"), struct MHIUAEBase *base __asm("a6"));
+ULONG i_MHIQuery(ULONG query __asm("d1"), struct MHIUAEBase *base __asm("a6"));
+void i_MHISetParam(APTR handle __asm("a3"), UWORD param __asm("d0"), ULONG value __asm("d1"), struct MHIUAEBase *base __asm("a6"));
+
+#endif

--- a/drivers/mhi/src/mhiuae_startup.c
+++ b/drivers/mhi/src/mhiuae_startup.c
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Dimitris Panokostas
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#define __USE_SYSBASE
+
+#include <stdint.h>
+
+#include <exec/execbase.h>
+#include <exec/initializers.h>
+#include <exec/memory.h>
+#include <exec/resident.h>
+#include <proto/exec.h>
+
+#include "mhiuae.h"
+
+struct ExecBase *SysBase = NULL;
+
+extern APTR FuncTab[];
+extern struct MyDataInit DataTab;
+extern APTR EndResident;
+
+struct MHIUAEBase *InitLib(struct ExecBase *sysbase __asm("a6"), BPTR seglist __asm("a0"), struct MHIUAEBase *base __asm("d0"));
+struct MHIUAEBase *OpenLib(struct MHIUAEBase *base __asm("a6"));
+BPTR CloseLib(struct MHIUAEBase *base __asm("a6"));
+BPTR ExpungeLib(struct MHIUAEBase *base __asm("a6"));
+ULONG ExtFuncLib(void);
+
+static const char lib_name[] __attribute__((used)) = MHIUAE_LIBRARY_NAME;
+static const char lib_id[] __attribute__((used)) = MHIUAE_LIBRARY_NAME " " VERSION_STR " (" DATE_STR ")";
+static const char ver_string[] __attribute__((used)) = "\0$VER: " MHIUAE_LIBRARY_NAME " " VERSION_STR " (" DATE_STR ")";
+
+#define MHIUAE_INIT_PTR(value) ((ULONG)(uintptr_t)(value))
+
+LONG LibStart(void)
+{
+    return -1;
+}
+
+struct InitTable {
+    ULONG lib_base_size;
+    APTR *function_table;
+    struct MyDataInit *data_table;
+    APTR init_function;
+};
+
+struct InitTable InitTab = {
+    sizeof(struct MHIUAEBase),
+    &FuncTab[0],
+    &DataTab,
+    InitLib
+};
+
+APTR FuncTab[] = {
+    OpenLib,
+    CloseLib,
+    ExpungeLib,
+    ExtFuncLib,
+    i_MHIAllocDecoder,
+    i_MHIFreeDecoder,
+    i_MHIQueueBuffer,
+    i_MHIGetEmpty,
+    i_MHIGetStatus,
+    i_MHIPlay,
+    i_MHIStop,
+    i_MHIPause,
+    i_MHIQuery,
+    i_MHISetParam,
+    (APTR)((LONG)-1)
+};
+
+struct Resident ROMTag __attribute__((used)) = {
+    RTC_MATCHWORD,
+    &ROMTag,
+    &EndResident,
+    RTF_AUTOINIT,
+    LIB_VERSION,
+    NT_LIBRARY,
+    0,
+    (char *)&lib_name[0],
+    (char *)&lib_id[0],
+    &InitTab
+};
+
+APTR EndResident;
+
+struct MyDataInit {
+    UWORD ln_Type_Init;      UWORD ln_Type_Offset;      UWORD ln_Type_Content;
+    UBYTE ln_Name_Init;      UBYTE ln_Name_Offset;      ULONG ln_Name_Content;
+    UWORD lib_Flags_Init;    UWORD lib_Flags_Offset;    UWORD lib_Flags_Content;
+    UWORD lib_Version_Init;  UWORD lib_Version_Offset;  UWORD lib_Version_Content;
+    UWORD lib_Revision_Init; UWORD lib_Revision_Offset; UWORD lib_Revision_Content;
+    UBYTE lib_IdString_Init; UBYTE lib_IdString_Offset; ULONG lib_IdString_Content;
+    ULONG end_mark;
+} DataTab = {
+    INITBYTE(OFFSET(Node, ln_Type), NT_LIBRARY),
+    0x80, (UBYTE)OFFSET(Node, ln_Name), MHIUAE_INIT_PTR(&lib_name[0]),
+    INITBYTE(OFFSET(Library, lib_Flags), LIBF_SUMUSED | LIBF_CHANGED),
+    INITWORD(OFFSET(Library, lib_Version), LIB_VERSION),
+    INITWORD(OFFSET(Library, lib_Revision), LIB_REVISION),
+    0x80, (UBYTE)OFFSET(Library, lib_IdString), MHIUAE_INIT_PTR(&lib_id[0]),
+    0
+};
+
+struct MHIUAEBase *InitLib(struct ExecBase *sysbase __asm("a6"), BPTR seglist __asm("a0"), struct MHIUAEBase *base __asm("d0"))
+{
+    ULONG negsize;
+    ULONG possize;
+    ULONG fullsize;
+    UBYTE *negptr;
+
+    SysBase = sysbase;
+    base->sys_base = sysbase;
+    base->seg_list = seglist;
+    base->allocated_decoders = 0;
+
+    if (mhiuae_open_uae()) {
+        return base;
+    }
+
+    negsize = base->lib.lib_NegSize;
+    possize = base->lib.lib_PosSize;
+    fullsize = negsize + possize;
+    negptr = (UBYTE *)base - negsize;
+    FreeMem(negptr, fullsize);
+    return NULL;
+}
+
+struct MHIUAEBase *OpenLib(struct MHIUAEBase *base __asm("a6"))
+{
+    base->lib.lib_OpenCnt++;
+    base->lib.lib_Flags &= ~LIBF_DELEXP;
+    return base;
+}
+
+BPTR CloseLib(struct MHIUAEBase *base __asm("a6"))
+{
+    if (base->lib.lib_OpenCnt > 0) {
+        base->lib.lib_OpenCnt--;
+    }
+    if (base->lib.lib_OpenCnt == 0 && (base->lib.lib_Flags & LIBF_DELEXP)) {
+        return ExpungeLib(base);
+    }
+    return 0;
+}
+
+BPTR ExpungeLib(struct MHIUAEBase *base __asm("a6"))
+{
+    BPTR seglist;
+    ULONG negsize;
+    ULONG possize;
+    ULONG fullsize;
+    UBYTE *negptr;
+
+    if (base->lib.lib_OpenCnt != 0 || base->allocated_decoders != 0) {
+        base->lib.lib_Flags |= LIBF_DELEXP;
+        return 0;
+    }
+
+    seglist = base->seg_list;
+    Remove((struct Node *)base);
+    mhiuae_close_uae();
+
+    negsize = base->lib.lib_NegSize;
+    possize = base->lib.lib_PosSize;
+    fullsize = negsize + possize;
+    negptr = (UBYTE *)base - negsize;
+    FreeMem(negptr, fullsize);
+    return seglist;
+}
+
+ULONG ExtFuncLib(void)
+{
+    return 0;
+}

--- a/package/Help/Host-Tools.guide
+++ b/package/Help/Host-Tools.guide
@@ -11,6 +11,7 @@ Installed components:
 @{"Command tools" link Commands}
 @{"UAE AHI audio driver" link AHI}
 @{"UAESND AHI audio driver" link UAESND}
+@{"UAE MHI MP3 decoder" link MHI}
 @{"Installation notes" link InstallNotes}
 
 @endnode
@@ -65,6 +66,19 @@ uaesnd: HiFi Stereo uses 32 bit stereo output.
 uaesnd: 7.1 uses 32 bit multichannel output.
 
 The installer does not change AHI preferences. Select a uaesnd mode in AHI preferences yourself if you want it to become the active output mode.
+
+@endnode
+
+@node MHI "UAE MHI MP3 Decoder"
+The UAE MHI MP3 decoder library is installed only when selected in the installer.
+
+Installed file:
+
+Libs/MHI/mhiuae.library
+
+The library implements the classic MHI decoder ABI and forwards MP3 buffers to Amiberry through uae.resource. Amiberry decodes the stream with its host mpg123 decoder and feeds the result into the emulator audio mixer, so MP3 playback does not consume Amiga CPU time.
+
+The library does not require or configure an AHI mode. It can be used alongside Paula, UAE AHI, UAESND AHI, or another selected AHI driver.
 
 @endnode
 

--- a/package/Install
+++ b/package/Install
@@ -5,7 +5,7 @@
 (set @default-dest "")
 
 (welcome
-	"Host-Tools installs command line tools and the optional UAE and UAESND AHI audio drivers for classic AmigaOS 68k systems running under Amiberry."
+	"Host-Tools installs command line tools and the optional UAE and UAESND AHI audio drivers and UAE MHI MP3 decoder library for classic AmigaOS 68k systems running under Amiberry."
 )
 
 (procedure P_SetVersionFields #_source #_destfile
@@ -125,6 +125,16 @@
 		(source #_source)
 		(dest #_destdir)
 		(files)
+	)
+)
+
+(procedure P_EnsureDir #_destdir
+	(if
+		(NOT (exists #_destdir))
+		(makedir #_destdir
+			(prompt (cat "Create " #_destdir))
+			(help @makedir-help)
+		)
 	)
 )
 
@@ -249,6 +259,13 @@
 	)
 )
 
+(procedure P_InstallMHILibrary
+	(
+		(P_EnsureDir "LIBS:MHI")
+		(P_CopySelectedVersionedFile "UAE MHI MP3 decoder library" "Libs/MHI/mhiuae.library" "LIBS:MHI" "mhiuae.library")
+	)
+)
+
 (set #help-language
 	(getenv "Language")
 )
@@ -263,7 +280,7 @@
 
 (if
 	(= @user-level 0)
-	(set #install-components 15)
+	(set #install-components 31)
 	(set #install-components
 		(askoptions
 			(prompt
@@ -271,7 +288,8 @@
 				"Command tools: host commands to C:.\n"
 				"Docs: Host-Tools.guide to HELP:.\n"
 				"UAE AHI: uae.audio and UAE AudioMode.\n"
-				"UAESND AHI: uaesnd.audio and UAESND AudioMode."
+				"UAESND AHI: uaesnd.audio and UAESND AudioMode.\n"
+				"MHI MP3: mhiuae.library to LIBS:MHI."
 			)
 			(help
 				"All components are selected by default. Novice installs every component and replaces existing files without further questions. Intermediate lets you select components, then copies versioned files automatically and replaces unversioned files. Expert shows installed and package versions before replacing existing versioned files, and asks before replacing unversioned files. No startup files, AHI preferences, or system preferences are changed."
@@ -281,8 +299,9 @@
 				"AmigaGuide documentation"
 				"UAE AHI audio driver"
 				"UAESND AHI audio driver"
+				"UAE MHI MP3 decoder"
 			)
-			(default 15)
+			(default 31)
 		)
 	)
 )
@@ -313,6 +332,10 @@
 
 (if (BITAND #install-components 8)
 	(P_InstallUAESNDDriver)
+)
+
+(if (BITAND #install-components 16)
+	(P_InstallMHILibrary)
 )
 
 (exit)

--- a/src/uae_pragmas.h
+++ b/src/uae_pragmas.h
@@ -217,4 +217,65 @@ static int UAE_UNUSED HostShell_View(UBYTE *filename)
     return calltrap(89, filename);
 }
 
+#define UAE_MHI_TRAP_ALLOC 110
+#define UAE_MHI_TRAP_FREE 111
+#define UAE_MHI_TRAP_QUEUE 112
+#define UAE_MHI_TRAP_GET_EMPTY 113
+#define UAE_MHI_TRAP_STATUS 114
+#define UAE_MHI_TRAP_PLAY 115
+#define UAE_MHI_TRAP_STOP 116
+#define UAE_MHI_TRAP_PAUSE 117
+#define UAE_MHI_TRAP_SET_PARAM 118
+#define UAE_MHI_TRAP_QUERY 119
+
+static ULONG UAE_UNUSED UaeMHIAlloc(APTR task, ULONG sigmask)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_ALLOC, task, sigmask);
+}
+
+static ULONG UAE_UNUSED UaeMHIFree(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_FREE, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHIQueue(ULONG handle, APTR buffer, ULONG size, ULONG token)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_QUEUE, handle, buffer, size, token);
+}
+
+static ULONG UAE_UNUSED UaeMHIGetEmpty(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_GET_EMPTY, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHIStatus(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_STATUS, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHIPlay(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_PLAY, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHIStop(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_STOP, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHIPause(ULONG handle)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_PAUSE, handle);
+}
+
+static ULONG UAE_UNUSED UaeMHISetParam(ULONG handle, ULONG param, ULONG value)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_SET_PARAM, handle, param, value);
+}
+
+static ULONG UAE_UNUSED UaeMHIQuery(ULONG query)
+{
+    return (ULONG)calltrap(UAE_MHI_TRAP_QUERY, query);
+}
+
 #endif

--- a/tests/test_package_layout.sh
+++ b/tests/test_package_layout.sh
@@ -142,6 +142,8 @@ grep -q 'UAE :16 bit HIFI Stereo++' "$PACKAGE_ROOT/Help/Host-Tools.guide"
 grep -q 'uaesnd: Stereo' "$PACKAGE_ROOT/Help/Host-Tools.guide"
 grep -q 'uaesnd: HiFi Stereo' "$PACKAGE_ROOT/Help/Host-Tools.guide"
 grep -q 'uaesnd: 7.1' "$PACKAGE_ROOT/Help/Host-Tools.guide"
+grep -q 'UAE MHI MP3 Decoder' "$PACKAGE_ROOT/Help/Host-Tools.guide"
+grep -q 'Libs/MHI/mhiuae.library' "$PACKAGE_ROOT/Help/Host-Tools.guide"
 
 for icon in "$PACKAGE_ROOT/Help/Host-Tools.guide.info"; do
 	magic="$(od -An -tx1 -N2 "$icon" | tr -d ' \n')"
@@ -163,16 +165,19 @@ grep -q "(askoptions" "$PACKAGE_ROOT/Install"
 grep -q "(= @user-level 0)" "$PACKAGE_ROOT/Install"
 grep -q "(= @user-level 1)" "$PACKAGE_ROOT/Install"
 grep -q "(= @user-level 2)" "$PACKAGE_ROOT/Install"
-grep -q "(set #install-components 15)" "$PACKAGE_ROOT/Install"
+grep -q "(set #install-components 31)" "$PACKAGE_ROOT/Install"
 grep -q "(procedure P_ReplaceFile" "$PACKAGE_ROOT/Install"
+grep -q "(procedure P_EnsureDir" "$PACKAGE_ROOT/Install"
 grep -q "(procedure P_CopyVersionedFileAutomatic" "$PACKAGE_ROOT/Install"
 grep -q "(procedure P_CopyPlainFileAutomatic" "$PACKAGE_ROOT/Install"
 grep -q '"Command tools"' "$PACKAGE_ROOT/Install"
 grep -q '"AmigaGuide documentation"' "$PACKAGE_ROOT/Install"
 grep -q '"UAE AHI audio driver"' "$PACKAGE_ROOT/Install"
+grep -q '"UAE MHI MP3 decoder"' "$PACKAGE_ROOT/Install"
 grep -q "Command tools: host commands to C:" "$PACKAGE_ROOT/Install"
 grep -q "Docs: Host-Tools.guide to HELP:" "$PACKAGE_ROOT/Install"
 grep -q "UAE AHI: uae.audio and UAE AudioMode." "$PACKAGE_ROOT/Install"
+grep -q "MHI MP3: mhiuae.library to LIBS:MHI." "$PACKAGE_ROOT/Install"
 if grep -q "Intermediate installs selected components automatically" "$PACKAGE_ROOT/Install"; then
 	echo "Installer component checklist prompt should not explain standard Intermediate/Expert behavior" >&2
 	exit 1
@@ -180,6 +185,7 @@ fi
 grep -q "(BITAND #install-components 1)" "$PACKAGE_ROOT/Install"
 grep -q "(BITAND #install-components 2)" "$PACKAGE_ROOT/Install"
 grep -q "(BITAND #install-components 4)" "$PACKAGE_ROOT/Install"
+grep -q "(BITAND #install-components 16)" "$PACKAGE_ROOT/Install"
 if grep -q "(IN #install-components" "$PACKAGE_ROOT/Install"; then
 	echo "Installer component checks should use BITAND for compatibility with common Installer scripts" >&2
 	exit 1
@@ -303,8 +309,17 @@ grep -q "(procedure P_InstallUAESNDDriver" "$PACKAGE_ROOT/Install"
 grep -q '"Devs/AHI/uaesnd.audio"' "$PACKAGE_ROOT/Install"
 grep -q '"Devs/AudioModes/UAESND"' "$PACKAGE_ROOT/Install"
 grep -q "(BITAND #install-components 8)" "$PACKAGE_ROOT/Install"
-grep -q "(default 15)" "$PACKAGE_ROOT/Install"
+grep -q "(default 31)" "$PACKAGE_ROOT/Install"
 grep -q "UAESND AHI: uaesnd.audio and UAESND AudioMode." "$PACKAGE_ROOT/Install"
+
+test -f "$PACKAGE_ROOT/Libs/MHI/mhiuae.library"
+grep -a -q '\$VER: mhiuae.library 2.4 (2026-06-10)' "$PACKAGE_ROOT/Libs/MHI/mhiuae.library"
+grep -q "UAE MHI MP3 decoder library" "$PACKAGE_ROOT/Install"
+grep -q "(procedure P_InstallMHILibrary" "$PACKAGE_ROOT/Install"
+grep -q '"Libs/MHI/mhiuae.library"' "$PACKAGE_ROOT/Install"
+grep -q '"LIBS:MHI"' "$PACKAGE_ROOT/Install"
+grep -q '(P_EnsureDir "LIBS:MHI")' "$PACKAGE_ROOT/Install"
+grep -q "(makedir #_destdir" "$PACKAGE_ROOT/Install"
 
 package_dry_run="$(make -n package PACKAGE_DIR="${PACKAGE_DIR}-dryrun")"
 case "$package_dry_run" in


### PR DESCRIPTION
## Summary
- add mhiuae.library as a classic MHI decoder wrapper over uae.resource traps
- package the library under Libs/MHI and install it to LIBS:MHI
- document the new component in README and AmigaGuide
- make the AHI assembler lookup work with the Docker compiler image PATH layout

## Validation
- docker run --rm -v "$PWD":/work -w /work sacredbanana/amiga-compiler:m68k-amigaos sh -lc 'make clean && make all && sh tests/test_ahi_driver_source.sh && sh tests/test_package_layout.sh'\n- docker run --rm -v "$PWD":/work -w /work sacredbanana/amiga-compiler:m68k-amigaos make package\n- native host command-builder test binaries\n- git diff --check\n\n## Notes\n- The MHI library is independent of the active AHI mode; it forwards MP3 decoding to Amiberry.